### PR TITLE
Removed shoot through warning, as board is protected against this.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Hardware design on [Github: rp2040-motor-controller](https://github.com/Twisted-
 
 :warning: Current version depends on unreleased changes to the SimpleFOC library. To compile this project before the release of SimpleFOC 2.2.3, please git clone the [SimpleFOC dev branch](https://github.com/simplefoc/Arduino-FOC/tree/dev) into the lib/ directory of this project.
 
-:warning: Twisted fields controller uses active-low polarity for low-side switches! Be sure to set `-DSIMPLEFOC_PWM_LOWSIDE_ACTIVE_HIGH=false` in the build. If you don't do this, you'll be producing guaranteed shoot-through, and will probably burn out the driver board.
-
+:warning: Twisted fields controller uses active-low polarity for low-side switches. Be sure to set `-DSIMPLEFOC_PWM_LOWSIDE_ACTIVE_HIGH=false` in the build or the board will not work properly and something may be damaged.
 
 This project is set up to use PlatformIO. You can try in other environments, your mileage may vary. In particular, the board definition for the Twisted Fields RP2040 motor controller for PlatformIO is included in this project, and its equivalent for other environments would have to be configured first.
 


### PR DESCRIPTION
I updated the readme. The board is hardware protected against shoot-through, so the specific warning against shoot-through is incorrect. However something bad may still happen, so I changed the text to communicate this.